### PR TITLE
Improve warning line/column accuracy and error messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,11 +74,12 @@ jobs:
             plts-v1-${{ matrix.otp_version }}-${{ matrix.elixir_version }}-
 
       - name: Run dialyzer
+        id: dialyzer
         run: mix dialyzer --format github
 
       - name: Save dialyzer cache
         uses: actions/cache/save@v4
-        if: always()
+        if: always() && steps.dialyzer.outcome != 'skipped'
         with:
           path: priv/plts
           key: plts-v1-${{ matrix.otp_version }}-${{ matrix.elixir_version }}-${{ hashFiles('mix.lock') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ All notable changes to this project will be documented in this file.
 
 ### Improved
 - Validation errors originating in external fragments (passed via the `fragments:` option) now include context identifying the fragment name and line, and point to the `...FragmentName` spread in the query rather than the sigil line.
-- Validation errors of the form `expected value of type X, found a variable` (produced by apollo-compiler when a variable is used for an input object field with an incompatible type) are now enriched with the variable name and its declared type, e.g. `expected value of type ID!, found variable \`$traveller_guid\` of type \`String!\``
+- Validation errors of the form `expected value of type X, found a variable` (produced by apollo-compiler when a variable is used for an input object field with an incompatible type) are now enriched with the variable name and its declared type, e.g.:
+
+  ```
+  expected value of type ID!, found variable `$guid` of type `String!`
+  ```
 - Added `THIRD_PARTY_LICENSES.md` documenting the apollo-compiler dependency (MIT/Apache-2.0).
 
 ## [v0.6.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Fixed
+- Warning line and column numbers are now accurate for all macro variants (`~GQL` sigil, `gql` heredoc, `gql` inline string, `gql_from_file`). Previously, line numbers were off by one due to a spurious `+1` in the offset calculation.
+- Single-line `gql("...")` string arguments now correctly map errors to the call site line.
+- `gql_from_file` errors now report lines relative to the external file rather than the call site.
+- Runtime validation no longer double-formats error messages.
+
+### Improved
+- Validation errors originating in external fragments (passed via the `fragments:` option) now include context identifying the fragment name and line, and point to the `...FragmentName` spread in the query rather than the sigil line.
+- Validation errors of the form `expected value of type X, found a variable` (produced by apollo-compiler when a variable is used for an input object field with an incompatible type) are now enriched with the variable name and its declared type, e.g. `expected value of type ID!, found variable \`$traveller_guid\` of type \`String!\``
+- Added `THIRD_PARTY_LICENSES.md` documenting the apollo-compiler dependency (MIT/Apache-2.0).
 
 ## [v0.6.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 - Validation errors originating in external fragments (passed via the `fragments:` option) now include context identifying the fragment name and line, and point to the `...FragmentName` spread in the query rather than the sigil line.
 - Validation errors of the form `expected value of type X, found a variable` (produced by apollo-compiler when a variable is used for an input object field with an incompatible type) are now enriched with the variable name and its declared type, e.g.:
 
-  ```
+  ```text
   expected value of type ID!, found variable `$guid` of type `String!`
   ```
 - Added `THIRD_PARTY_LICENSES.md` documenting the apollo-compiler dependency (MIT/Apache-2.0).

--- a/README.md
+++ b/README.md
@@ -874,6 +874,8 @@ Check the documentation of these modules if you want to know more about the manu
 ## License
 Beerware 🍺 — do whatever you want with it, but if we meet, buy me a beer. (This is essentially MIT-like. Use it freely, but if we meet, buy me a beer)
 
+This library uses [apollo-compiler](https://github.com/apollographql/apollo-rs) for GraphQL parsing and validation, which is licensed under MIT/Apache-2.0. See [THIRD_PARTY_LICENSES.md](THIRD_PARTY_LICENSES.md) for details.
+
 <!-- MDOC -->
 
 ---

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,59 @@
+# Third-Party Licenses
+
+This project includes compiled code from the following third-party libraries
+in its precompiled NIF binaries.
+
+---
+
+## apollo-compiler
+
+- **Repository:** https://github.com/apollographql/apollo-rs
+- **License:** MIT OR Apache-2.0
+- **Copyright:** 2021 Apollo Graph, Inc.
+
+Used for GraphQL query parsing, validation, and formatting in the Rust NIF
+(`native/graphql_query_native/`).
+
+### MIT License
+
+```
+Copyright 2021 Apollo Graph, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+---
+
+## rustler
+
+- **Repository:** https://github.com/rusterlium/rustler
+- **License:** Apache-2.0 OR MIT
+- **Copyright:** rustler contributors
+
+Used as the Erlang NIF binding layer for Rust.
+
+---
+
+## regex
+
+- **Repository:** https://github.com/rust-lang/regex
+- **License:** MIT OR Apache-2.0
+- **Copyright:** regex contributors
+
+Used for regular expression support in the Rust NIF.

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -16,7 +16,7 @@ Used for GraphQL query parsing, validation, and formatting in the Rust NIF
 
 ### MIT License
 
-```
+```text
 Copyright 2021 Apollo Graph, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/lib/graphql_query.ex
+++ b/lib/graphql_query.ex
@@ -467,7 +467,7 @@ defmodule GraphqlQuery do
     warn_location = warn_location([], caller)
     # For single-line binary strings, the content is on the same line as the call.
     # Use caller.line - 1 as base so that error line 1 maps to caller.line.
-    inline_meta = [line: caller.line - 1]
+    inline_meta = [line: max(caller.line - 1, 0)]
 
     case validate_options(opts, caller) do
       {:ok, opts} ->
@@ -1087,26 +1087,20 @@ defmodule GraphqlQuery do
             query
 
           {:ok, warnings} ->
-            line_map = GraphqlQuery.Parser.build_line_map(query)
-            query_text = GraphqlQuery.Document.format_query_with_fragments(query)
+            diagnostics =
+              GraphqlQuery.Validator.emit_validation_diagnostics(
+                warnings,
+                unquote(warn_location),
+                :runtime,
+                query,
+                fn warning ->
+                  message = GraphqlQuery.format_warning(warning)
+                  %GraphqlQuery.ValidationError{message: message, locations: warning.locations}
+                end
+              )
 
-            Enum.each(warnings, fn warning ->
-              message = GraphqlQuery.format_warning(warning)
-
-              ve = %GraphqlQuery.ValidationError{message: message, locations: warning.locations}
-              ve = GraphqlQuery.Parser.enrich_error_message(ve, query_text)
-              {ve, frag_ctx} = GraphqlQuery.maybe_adjust_for_fragment(ve, line_map)
-
-              error =
-                GraphqlQuery.Parser.format_error(
-                  ve,
-                  unquote(warn_location),
-                  :runtime
-                )
-
-              msg = GraphqlQuery.append_fragment_context(error.message, frag_ctx)
-
-              GraphqlQuery.Logger.warning(msg, error.location)
+            Enum.each(diagnostics, fn {message, location} ->
+              GraphqlQuery.Logger.warning(message, location)
             end)
 
             query
@@ -1116,16 +1110,17 @@ defmodule GraphqlQuery do
           query
 
         {:error, errors} ->
-          line_map = GraphqlQuery.Parser.build_line_map(query)
-          query_text = GraphqlQuery.Document.format_query_with_fragments(query)
+          diagnostics =
+            GraphqlQuery.Validator.emit_validation_diagnostics(
+              errors,
+              unquote(warn_location),
+              :runtime,
+              query,
+              & &1
+            )
 
-          Enum.each(errors, fn error ->
-            error = GraphqlQuery.Parser.enrich_error_message(error, query_text)
-            {error, frag_ctx} = GraphqlQuery.maybe_adjust_for_fragment(error, line_map)
-            error = GraphqlQuery.Parser.format_error(error, unquote(warn_location), :runtime)
-            msg = GraphqlQuery.append_fragment_context(error.message, frag_ctx)
-
-            GraphqlQuery.Logger.warning(msg, error.location)
+          Enum.each(diagnostics, fn {message, location} ->
+            GraphqlQuery.Logger.warning(message, location)
           end)
 
           query
@@ -1159,42 +1154,22 @@ defmodule GraphqlQuery do
   end
 
   defp print_warnings(errors, warn_location, prefix, document) do
-    line_map = Parser.build_line_map(document)
+    diagnostics = Validator.emit_validation_diagnostics(errors, warn_location, prefix, document, & &1)
 
-    query_text = extract_query_text(document)
-
-    Enum.each(errors, fn error ->
-      error = Parser.enrich_error_message(error, query_text)
-      {error, fragment_ctx} = maybe_adjust_for_fragment(error, line_map)
-      formatted = Parser.format_error(error, warn_location, prefix)
-      message = append_fragment_context(formatted.message, fragment_ctx)
-
-      GraphqlQuery.Logger.warning(message, formatted.location)
+    Enum.each(diagnostics, fn {message, location} ->
+      GraphqlQuery.Logger.warning(message, location)
     end)
   end
 
   defp print_typed_warnings(warnings, warn_location, document) do
-    line_map = Parser.build_line_map(document)
+    diagnostics =
+      Validator.emit_validation_diagnostics(warnings, warn_location, "", document, fn warning ->
+        message = format_warning(warning)
+        %ValidationError{message: message, locations: warning.locations}
+      end)
 
-    query_text = extract_query_text(document)
-
-    Enum.each(warnings, fn warning ->
-      message = GraphqlQuery.format_warning(warning)
-
-      validation_error = %ValidationError{message: message, locations: warning.locations}
-      validation_error = Parser.enrich_error_message(validation_error, query_text)
-      {validation_error, fragment_ctx} = maybe_adjust_for_fragment(validation_error, line_map)
-
-      formatted =
-        Parser.format_error(
-          validation_error,
-          warn_location,
-          ""
-        )
-
-      message = append_fragment_context(formatted.message, fragment_ctx)
-
-      GraphqlQuery.Logger.warning(message, formatted.location)
+    Enum.each(diagnostics, fn {message, location} ->
+      GraphqlQuery.Logger.warning(message, location)
     end)
   end
 
@@ -1208,11 +1183,17 @@ defmodule GraphqlQuery do
       {:fragment, name, relative_line} ->
         # Error is within an appended fragment. Point to the ...FragmentName
         # spread line in the query so the user sees where the fragment is used.
-        # If the spread isn't found, fall back to line 0 (the sigil line).
-        spread_line = Parser.find_spread_line(line_map, name) || 0
-        adjusted_loc = %{loc | line: spread_line, column: 0}
-        adjusted_error = %{error | locations: [adjusted_loc | rest]}
-        {adjusted_error, {:fragment, name, relative_line}}
+        # If the spread isn't found, preserve the original loc so the user
+        # still sees the fragment-relative line plus appended context.
+        case Parser.find_spread_line(line_map, name) do
+          nil ->
+            {error, {:fragment, name, relative_line}}
+
+          spread_line ->
+            adjusted_loc = %{loc | line: spread_line, column: 0}
+            adjusted_error = %{error | locations: [adjusted_loc | rest]}
+            {adjusted_error, {:fragment, name, relative_line}}
+        end
 
       {:query, _relative_line} ->
         {error, nil}
@@ -1230,9 +1211,10 @@ defmodule GraphqlQuery do
     message <> "\n  in fragment '#{name}' at line #{line} (included via fragments option)"
   end
 
-  defp extract_query_text(%Document{} = doc), do: Document.format_query_with_fragments(doc)
-  defp extract_query_text(%Fragment{fragment: text}), do: text
-  defp extract_query_text(_), do: nil
+  @doc false
+  def extract_query_text(%Document{} = doc), do: Document.format_query_with_fragments(doc)
+  def extract_query_text(%Fragment{fragment: text}), do: text
+  def extract_query_text(_), do: nil
 
   @doc """
   Formats a `GraphqlQuery.ValidationWarning` into a human-readable string.

--- a/lib/graphql_query.ex
+++ b/lib/graphql_query.ex
@@ -1159,7 +1159,9 @@ defmodule GraphqlQuery do
   end
 
   defp print_warnings(errors, warn_location, prefix, document) do
-    line_map = if document, do: Parser.build_line_map(document), else: %{segments: [], spreads: %{}}
+    line_map =
+      if document, do: Parser.build_line_map(document), else: %{segments: [], spreads: %{}}
+
     query_text = extract_query_text(document)
 
     Enum.each(errors, fn error ->
@@ -1173,7 +1175,9 @@ defmodule GraphqlQuery do
   end
 
   defp print_typed_warnings(warnings, warn_location, document) do
-    line_map = if document, do: Parser.build_line_map(document), else: %{segments: [], spreads: %{}}
+    line_map =
+      if document, do: Parser.build_line_map(document), else: %{segments: [], spreads: %{}}
+
     query_text = extract_query_text(document)
 
     Enum.each(warnings, fn warning ->

--- a/lib/graphql_query.ex
+++ b/lib/graphql_query.ex
@@ -1159,8 +1159,7 @@ defmodule GraphqlQuery do
   end
 
   defp print_warnings(errors, warn_location, prefix, document) do
-    line_map =
-      if document, do: Parser.build_line_map(document), else: %{segments: [], spreads: %{}}
+    line_map = Parser.build_line_map(document)
 
     query_text = extract_query_text(document)
 
@@ -1175,8 +1174,7 @@ defmodule GraphqlQuery do
   end
 
   defp print_typed_warnings(warnings, warn_location, document) do
-    line_map =
-      if document, do: Parser.build_line_map(document), else: %{segments: [], spreads: %{}}
+    line_map = Parser.build_line_map(document)
 
     query_text = extract_query_text(document)
 

--- a/lib/graphql_query.ex
+++ b/lib/graphql_query.ex
@@ -367,7 +367,8 @@ defmodule GraphqlQuery do
     caller = __CALLER__
 
     file_path = gql_from_file_expand_path!(file_path, caller)
-    warn_location = [file: file_path]
+    # line: 0 so error lines are purely within the external file
+    warn_location = [file: file_path, line: 0]
     module_opts = get_module_opts(caller)
 
     contents = read_gql_file!(file_path, caller)
@@ -382,7 +383,8 @@ defmodule GraphqlQuery do
 
     contents = read_gql_file!(file_path, caller)
 
-    do_gql_validate_options(contents, [contents], caller, [file: file_path], opts)
+    # line: 0 so error lines are purely within the external file
+    do_gql_validate_options(contents, [contents], caller, [file: file_path, line: 0], opts)
   end
 
   defp gql_from_file_expand_path!(ast, caller) do
@@ -463,6 +465,9 @@ defmodule GraphqlQuery do
   defmacro gql(opts, content) when is_binary(content) do
     caller = __CALLER__
     warn_location = warn_location([], caller)
+    # For single-line binary strings, the content is on the same line as the call.
+    # Use caller.line - 1 as base so that error line 1 maps to caller.line.
+    inline_meta = [line: caller.line - 1]
 
     case validate_options(opts, caller) do
       {:ok, opts} ->
@@ -472,7 +477,7 @@ defmodule GraphqlQuery do
 
         cond do
           ignore? ->
-            do_gql(content, [content], caller, [], opts)
+            do_gql(content, [content], caller, inline_meta, opts)
 
           runtime_validation? ->
             # Validate on runtime
@@ -490,10 +495,10 @@ defmodule GraphqlQuery do
 
             GraphqlQuery.Logger.warning(msg, warn_location)
 
-            do_gql(content, [content], caller, [], opts)
+            do_gql(content, [content], caller, inline_meta, opts)
 
           true ->
-            do_gql(content, [content], caller, [], opts)
+            do_gql(content, [content], caller, inline_meta, opts)
         end
 
       {:error, error, field} ->
@@ -1082,17 +1087,26 @@ defmodule GraphqlQuery do
             query
 
           {:ok, warnings} ->
+            line_map = GraphqlQuery.Parser.build_line_map(query)
+            query_text = GraphqlQuery.Document.format_query_with_fragments(query)
+
             Enum.each(warnings, fn warning ->
               message = GraphqlQuery.format_warning(warning)
 
+              ve = %GraphqlQuery.ValidationError{message: message, locations: warning.locations}
+              ve = GraphqlQuery.Parser.enrich_error_message(ve, query_text)
+              {ve, frag_ctx} = GraphqlQuery.maybe_adjust_for_fragment(ve, line_map)
+
               error =
                 GraphqlQuery.Parser.format_error(
-                  %GraphqlQuery.ValidationError{message: message, locations: warning.locations},
+                  ve,
                   unquote(warn_location),
                   :runtime
                 )
 
-              GraphqlQuery.Logger.warning(error.message, error.location)
+              msg = GraphqlQuery.append_fragment_context(error.message, frag_ctx)
+
+              GraphqlQuery.Logger.warning(msg, error.location)
             end)
 
             query
@@ -1102,10 +1116,16 @@ defmodule GraphqlQuery do
           query
 
         {:error, errors} ->
-          Enum.each(errors, fn error ->
-            error = GraphqlQuery.Parser.format_error(error, unquote(warn_location), :runtime)
+          line_map = GraphqlQuery.Parser.build_line_map(query)
+          query_text = GraphqlQuery.Document.format_query_with_fragments(query)
 
-            GraphqlQuery.Logger.warning(error.message, error.location)
+          Enum.each(errors, fn error ->
+            error = GraphqlQuery.Parser.enrich_error_message(error, query_text)
+            {error, frag_ctx} = GraphqlQuery.maybe_adjust_for_fragment(error, line_map)
+            error = GraphqlQuery.Parser.format_error(error, unquote(warn_location), :runtime)
+            msg = GraphqlQuery.append_fragment_context(error.message, frag_ctx)
+
+            GraphqlQuery.Logger.warning(msg, error.location)
           end)
 
           query
@@ -1119,7 +1139,7 @@ defmodule GraphqlQuery do
         document
 
       {:ok, warnings} ->
-        print_typed_warnings(warnings, warn_location)
+        print_typed_warnings(warnings, warn_location, document)
         document
 
       {:error, errors} ->
@@ -1132,34 +1152,85 @@ defmodule GraphqlQuery do
               "Validation errors, if you want to ignore them use the i modifier: ~G\"{}\"i\n"
           end
 
-        print_warnings(errors, warn_location, prefix)
+        print_warnings(errors, warn_location, prefix, document)
 
         document
     end
   end
 
-  defp print_warnings(errors, warn_location, prefix) do
-    Enum.each(errors, fn error ->
-      error = Parser.format_error(error, warn_location, prefix)
+  defp print_warnings(errors, warn_location, prefix, document) do
+    line_map = if document, do: Parser.build_line_map(document), else: %{segments: [], spreads: %{}}
+    query_text = extract_query_text(document)
 
-      GraphqlQuery.Logger.warning(error.message, error.location)
+    Enum.each(errors, fn error ->
+      error = Parser.enrich_error_message(error, query_text)
+      {error, fragment_ctx} = maybe_adjust_for_fragment(error, line_map)
+      formatted = Parser.format_error(error, warn_location, prefix)
+      message = append_fragment_context(formatted.message, fragment_ctx)
+
+      GraphqlQuery.Logger.warning(message, formatted.location)
     end)
   end
 
-  defp print_typed_warnings(warnings, warn_location) do
+  defp print_typed_warnings(warnings, warn_location, document) do
+    line_map = if document, do: Parser.build_line_map(document), else: %{segments: [], spreads: %{}}
+    query_text = extract_query_text(document)
+
     Enum.each(warnings, fn warning ->
       message = GraphqlQuery.format_warning(warning)
 
-      error =
+      validation_error = %ValidationError{message: message, locations: warning.locations}
+      validation_error = Parser.enrich_error_message(validation_error, query_text)
+      {validation_error, fragment_ctx} = maybe_adjust_for_fragment(validation_error, line_map)
+
+      formatted =
         Parser.format_error(
-          %ValidationError{message: message, locations: warning.locations},
+          validation_error,
           warn_location,
           ""
         )
 
-      GraphqlQuery.Logger.warning(error.message, error.location)
+      message = append_fragment_context(formatted.message, fragment_ctx)
+
+      GraphqlQuery.Logger.warning(message, formatted.location)
     end)
   end
+
+  @doc false
+  def maybe_adjust_for_fragment(
+        %ValidationError{locations: [loc | rest]} = error,
+        %{segments: segments} = line_map
+      )
+      when segments != [] do
+    case Parser.resolve_error_source(loc.line, line_map) do
+      {:fragment, name, relative_line} ->
+        # Error is within an appended fragment. Point to the ...FragmentName
+        # spread line in the query so the user sees where the fragment is used.
+        # If the spread isn't found, fall back to line 0 (the sigil line).
+        spread_line = Parser.find_spread_line(line_map, name) || 0
+        adjusted_loc = %{loc | line: spread_line, column: 0}
+        adjusted_error = %{error | locations: [adjusted_loc | rest]}
+        {adjusted_error, {:fragment, name, relative_line}}
+
+      {:query, _relative_line} ->
+        {error, nil}
+    end
+  end
+
+  @doc false
+  def maybe_adjust_for_fragment(error, _line_map), do: {error, nil}
+
+  @doc false
+  def append_fragment_context(message, nil), do: message
+
+  @doc false
+  def append_fragment_context(message, {:fragment, name, line}) do
+    message <> "\n  in fragment '#{name}' at line #{line} (included via fragments option)"
+  end
+
+  defp extract_query_text(%Document{} = doc), do: Document.format_query_with_fragments(doc)
+  defp extract_query_text(%Fragment{fragment: text}), do: text
+  defp extract_query_text(_), do: nil
 
   @doc """
   Formats a `GraphqlQuery.ValidationWarning` into a human-readable string.

--- a/lib/graphql_query.ex
+++ b/lib/graphql_query.ex
@@ -1154,7 +1154,8 @@ defmodule GraphqlQuery do
   end
 
   defp print_warnings(errors, warn_location, prefix, document) do
-    diagnostics = Validator.emit_validation_diagnostics(errors, warn_location, prefix, document, & &1)
+    diagnostics =
+      Validator.emit_validation_diagnostics(errors, warn_location, prefix, document, & &1)
 
     Enum.each(diagnostics, fn {message, location} ->
       GraphqlQuery.Logger.warning(message, location)

--- a/lib/graphql_query/document.ex
+++ b/lib/graphql_query/document.ex
@@ -281,8 +281,8 @@ defmodule GraphqlQuery.Document do
   defp maybe_extract_unique_name(_), do: nil
 
   @doc false
-  @spec filter_used_fragments_public(t(), list(Fragment.t())) :: list(Fragment.t())
-  def filter_used_fragments_public(document, fragments) do
+  @spec filter_used_fragments_for(t(), list(Fragment.t())) :: list(Fragment.t())
+  def filter_used_fragments_for(document, fragments) do
     filter_used_fragments(fragments, document)
   end
 

--- a/lib/graphql_query/document.ex
+++ b/lib/graphql_query/document.ex
@@ -280,6 +280,12 @@ defmodule GraphqlQuery.Document do
 
   defp maybe_extract_unique_name(_), do: nil
 
+  @doc false
+  @spec filter_used_fragments_public(t(), list(Fragment.t())) :: list(Fragment.t())
+  def filter_used_fragments_public(document, fragments) do
+    filter_used_fragments(fragments, document)
+  end
+
   @doc "Format a query with its fragments into a single string."
   @spec format_query_with_fragments(t()) :: String.t()
   def format_query_with_fragments(%__MODULE__{query: query, fragments: fragments} = document) do

--- a/lib/graphql_query/logger.ex
+++ b/lib/graphql_query/logger.ex
@@ -16,11 +16,10 @@ defmodule GraphqlQuery.Logger do
         end
 
       _ ->
-        # Runtime call
+        # Runtime call - message is already formatted by the caller
         quote do
           require Logger
-          error = GraphqlQuery.Parser.format_error(unquote(message), unquote(location), :runtime)
-          Logger.warning(error, unquote(location))
+          Logger.warning(unquote(message), unquote(location))
         end
     end
   end

--- a/lib/graphql_query/parser.ex
+++ b/lib/graphql_query/parser.ex
@@ -160,7 +160,10 @@ defmodule GraphqlQuery.Parser do
   Returns the line number (1-indexed) or `nil` if the spread is not found.
   """
   def find_spread_line(%{spreads: spreads}, fragment_name) do
-    Map.get(spreads, fragment_name)
+    case Map.get(spreads, fragment_name) do
+      [first | _] -> first
+      _ -> nil
+    end
   end
 
   def find_spread_line(_, _), do: nil
@@ -170,6 +173,7 @@ defmodule GraphqlQuery.Parser do
     |> String.split("\n")
     |> Enum.with_index(1)
     |> Enum.reduce(%{}, &collect_spread_names/2)
+    |> Map.new(fn {name, lines} -> {name, Enum.sort(lines)} end)
   end
 
   defp collect_spread_names({line, line_num}, acc) do
@@ -179,7 +183,7 @@ defmodule GraphqlQuery.Parser do
 
       matches ->
         Enum.reduce(matches, acc, fn [_, name], inner_acc ->
-          Map.put_new(inner_acc, name, line_num)
+          Map.update(inner_acc, name, [line_num], fn existing -> [line_num | existing] end)
         end)
     end
   end
@@ -220,7 +224,7 @@ defmodule GraphqlQuery.Parser do
       [_, expected_type] ->
         with var_name when is_binary(var_name) <-
                extract_variable_at(query_text, loc.line, loc.column),
-             var_type when is_binary(var_type) <- find_variable_type(query_text, var_name) do
+             var_type when is_binary(var_type) <- find_variable_type(query_text, var_name, loc) do
           enriched =
             "expected value of type #{expected_type}, found variable `$#{var_name}` of type `#{var_type}`"
 
@@ -258,15 +262,31 @@ defmodule GraphqlQuery.Parser do
 
   # Finds the declared type of a variable by scanning operation definitions.
   # Looks for patterns like `$name: Type` or `$name: Type!` or `$name: [Type!]!`
-  defp find_variable_type(query_text, var_name) do
-    # Match $var_name followed by : and its type annotation.
-    # The type can include [], !, and nested combinations.
-    # We capture up to the next comma, closing paren, or equals sign (default value).
+  # When multiple operations declare the same variable, uses the error location
+  # to pick the closest preceding declaration.
+  defp find_variable_type(query_text, var_name, loc) do
     pattern = Regex.compile!("\\$" <> Regex.escape(var_name) <> "\\s*:\\s*([^,)=]+)")
+    lines = String.split(query_text, "\n")
 
-    case Regex.run(pattern, query_text) do
-      [_, type_str] -> String.trim(type_str)
-      _ -> nil
+    matches =
+      lines
+      |> Enum.with_index(1)
+      |> Enum.flat_map(fn {line_text, line_num} ->
+        case Regex.run(pattern, line_text) do
+          [_, type_str] -> [{line_num, String.trim(type_str)}]
+          _ -> []
+        end
+      end)
+
+    case matches do
+      [] -> nil
+      [{_line, type}] -> type
+      multiple ->
+        # Pick the declaration closest to but before the error line
+        case Enum.filter(multiple, fn {line_num, _} -> line_num <= loc.line end) do
+          [] -> multiple |> List.first() |> elem(1)
+          preceding -> preceding |> Enum.max_by(fn {line_num, _} -> line_num end) |> elem(1)
+        end
     end
   end
 end

--- a/lib/graphql_query/parser.ex
+++ b/lib/graphql_query/parser.ex
@@ -279,14 +279,21 @@ defmodule GraphqlQuery.Parser do
       end)
 
     case matches do
-      [] -> nil
-      [{_line, type}] -> type
+      [] ->
+        nil
+
+      [{_line, type}] ->
+        type
+
       multiple ->
-        # Pick the declaration closest to but before the error line
-        case Enum.filter(multiple, fn {line_num, _} -> line_num <= loc.line end) do
-          [] -> multiple |> List.first() |> elem(1)
-          preceding -> preceding |> Enum.max_by(fn {line_num, _} -> line_num end) |> elem(1)
-        end
+        pick_closest_declaration(multiple, loc)
+    end
+  end
+
+  defp pick_closest_declaration(matches, loc) do
+    case Enum.filter(matches, fn {line_num, _} -> line_num <= loc.line end) do
+      [] -> matches |> List.first() |> elem(1)
+      preceding -> preceding |> Enum.max_by(fn {line_num, _} -> line_num end) |> elem(1)
     end
   end
 end

--- a/lib/graphql_query/parser.ex
+++ b/lib/graphql_query/parser.ex
@@ -167,18 +167,19 @@ defmodule GraphqlQuery.Parser do
     query_text
     |> String.split("\n")
     |> Enum.with_index(1)
-    |> Enum.reduce(%{}, fn {line, line_num}, acc ->
-      case Regex.scan(~r/\.\.\.\s*(\w+)/, line) do
-        [] ->
-          acc
+    |> Enum.reduce(%{}, &collect_spread_names/2)
+  end
 
-        matches ->
-          Enum.reduce(matches, acc, fn [_, name], inner_acc ->
-            # Only keep the first occurrence of each spread
-            Map.put_new(inner_acc, name, line_num)
-          end)
-      end
-    end)
+  defp collect_spread_names({line, line_num}, acc) do
+    case Regex.scan(~r/\.\.\.\s*(\w+)/, line) do
+      [] ->
+        acc
+
+      matches ->
+        Enum.reduce(matches, acc, fn [_, name], inner_acc ->
+          Map.put_new(inner_acc, name, line_num)
+        end)
+    end
   end
 
   defp used_fragments_for(%GraphqlQuery.Document{fragments: fragments} = document) do

--- a/lib/graphql_query/parser.ex
+++ b/lib/graphql_query/parser.ex
@@ -215,7 +215,8 @@ defmodule GraphqlQuery.Parser do
       when is_binary(query_text) do
     case Regex.run(@found_variable_pattern, message) do
       [_, expected_type] ->
-        with var_name when is_binary(var_name) <- extract_variable_at(query_text, loc.line, loc.column),
+        with var_name when is_binary(var_name) <-
+               extract_variable_at(query_text, loc.line, loc.column),
              var_type when is_binary(var_type) <- find_variable_type(query_text, var_name) do
           enriched =
             "expected value of type #{expected_type}, found variable `$#{var_name}` of type `#{var_type}`"

--- a/lib/graphql_query/parser.ex
+++ b/lib/graphql_query/parser.ex
@@ -112,15 +112,17 @@ defmodule GraphqlQuery.Parser do
     # Build segments: query occupies lines 1..query_lines
     initial = [{:query, 1, query_lines}]
 
-    {segments, _} =
-      Enum.reduce(used_fragments, {initial, query_lines}, fn fragment, {acc, offset} ->
+    {segments_rev, _} =
+      Enum.reduce(used_fragments, {[], query_lines}, fn fragment, {acc, offset} ->
         frag_text = Kernel.to_string(fragment)
         frag_lines = count_lines(frag_text)
         start = offset + 1
         finish = offset + frag_lines
         name = fragment.name || "unnamed"
-        {acc ++ [{{:fragment, name}, start, finish}], finish}
+        {[{{:fragment, name}, start, finish} | acc], finish}
       end)
+
+    segments = initial ++ Enum.reverse(segments_rev)
 
     # Build spread locations: find `...FragmentName` in the query text
     spreads = find_spread_lines(query_text)
@@ -171,7 +173,7 @@ defmodule GraphqlQuery.Parser do
   end
 
   defp collect_spread_names({line, line_num}, acc) do
-    case Regex.scan(~r/\.\.\.\s*(\w+)/, line) do
+    case Regex.scan(~r/\.\.\.\s*(?!on\b)(\w+)/, line) do
       [] ->
         acc
 
@@ -183,7 +185,7 @@ defmodule GraphqlQuery.Parser do
   end
 
   defp used_fragments_for(%GraphqlQuery.Document{fragments: fragments} = document) do
-    GraphqlQuery.Document.filter_used_fragments_public(document, fragments)
+    GraphqlQuery.Document.filter_used_fragments_for(document, fragments)
   end
 
   defp count_lines(text) do

--- a/lib/graphql_query/parser.ex
+++ b/lib/graphql_query/parser.ex
@@ -78,7 +78,7 @@ defmodule GraphqlQuery.Parser do
         [location | _] -> location
       end
 
-    warn_line = if line = warn_location[:line], do: line + 1, else: 0
+    warn_line = warn_location[:line] || 0
     indentation = warn_location[:indentation] || 0
 
     # warn_location[:column] || 0
@@ -92,11 +92,177 @@ defmodule GraphqlQuery.Parser do
     Keyword.merge(warn_location, new_location)
   end
 
+  @doc """
+  Builds a line map for a document with its fragments.
+
+  Returns a map with:
+  - `:segments` — list of `{source, start_line, end_line}` tuples where source is
+    either `:query` or `{:fragment, name}`. Lines are 1-indexed and refer to
+    positions in the combined validation string (query + appended fragments).
+  - `:spreads` — map of `%{fragment_name => line_in_query}` indicating where each
+    fragment spread (`...FragmentName`) appears in the query text.
+  """
+  def build_line_map(%GraphqlQuery.Document{} = document) do
+    query_text = String.trim(document.query)
+    query_lines = count_lines(query_text)
+
+    # Get the used fragments in the same order as format_query_with_fragments
+    used_fragments = used_fragments_for(document)
+
+    # Build segments: query occupies lines 1..query_lines
+    initial = [{:query, 1, query_lines}]
+
+    {segments, _} =
+      Enum.reduce(used_fragments, {initial, query_lines}, fn fragment, {acc, offset} ->
+        frag_text = Kernel.to_string(fragment)
+        frag_lines = count_lines(frag_text)
+        start = offset + 1
+        finish = offset + frag_lines
+        name = fragment.name || "unnamed"
+        {acc ++ [{{:fragment, name}, start, finish}], finish}
+      end)
+
+    # Build spread locations: find `...FragmentName` in the query text
+    spreads = find_spread_lines(query_text)
+
+    %{segments: segments, spreads: spreads}
+  end
+
+  def build_line_map(_), do: %{segments: [], spreads: %{}}
+
+  @doc """
+  Resolves which source (query or fragment) an error line belongs to.
+
+  Returns `{:query, relative_line}` or `{:fragment, name, relative_line}`.
+  """
+  def resolve_error_source(error_line, %{segments: segments}) do
+    resolve_error_source(error_line, segments)
+  end
+
+  def resolve_error_source(error_line, segments) when is_list(segments) do
+    Enum.find_value(segments, {:query, error_line}, fn
+      {:query, start, finish} when error_line >= start and error_line <= finish ->
+        {:query, error_line - start + 1}
+
+      {{:fragment, name}, start, finish} when error_line >= start and error_line <= finish ->
+        {:fragment, name, error_line - start + 1}
+
+      _ ->
+        nil
+    end)
+  end
+
+  @doc """
+  Finds the line in the query where a fragment spread (`...FragmentName`) appears.
+
+  Returns the line number (1-indexed) or `nil` if the spread is not found.
+  """
+  def find_spread_line(%{spreads: spreads}, fragment_name) do
+    Map.get(spreads, fragment_name)
+  end
+
+  def find_spread_line(_, _), do: nil
+
+  defp find_spread_lines(query_text) do
+    query_text
+    |> String.split("\n")
+    |> Enum.with_index(1)
+    |> Enum.reduce(%{}, fn {line, line_num}, acc ->
+      case Regex.scan(~r/\.\.\.\s*(\w+)/, line) do
+        [] ->
+          acc
+
+        matches ->
+          Enum.reduce(matches, acc, fn [_, name], inner_acc ->
+            # Only keep the first occurrence of each spread
+            Map.put_new(inner_acc, name, line_num)
+          end)
+      end
+    end)
+  end
+
+  defp used_fragments_for(%GraphqlQuery.Document{fragments: fragments} = document) do
+    GraphqlQuery.Document.filter_used_fragments_public(document, fragments)
+  end
+
+  defp count_lines(text) do
+    text |> String.split("\n") |> length()
+  end
+
   defp error_prefix(prefix, _loc, _file_path) when is_binary(prefix) do
     prefix
   end
 
   defp error_prefix(:runtime, loc, file_path) do
     "Runtime Validation error @ #{file_path}:#{loc[:line]}:#{loc[:column]} ->"
+  end
+
+  # Pattern for apollo-compiler's UnsupportedValueType with a variable
+  @found_variable_pattern ~r/^expected value of type (.+), found a variable$/
+
+  @doc """
+  Enriches validation error messages that lack detail.
+
+  Apollo-compiler's `UnsupportedValueType` diagnostic produces messages like
+  `"expected value of type ID, found a variable"` without naming the variable
+  or its declared type. This function detects that pattern and enhances the
+  message using the query text and error location.
+  """
+  def enrich_error_message(
+        %GraphqlQuery.ValidationError{message: message, locations: [loc | _]} = error,
+        query_text
+      )
+      when is_binary(query_text) do
+    case Regex.run(@found_variable_pattern, message) do
+      [_, expected_type] ->
+        with var_name when is_binary(var_name) <- extract_variable_at(query_text, loc.line, loc.column),
+             var_type when is_binary(var_type) <- find_variable_type(query_text, var_name) do
+          enriched =
+            "expected value of type #{expected_type}, found variable `$#{var_name}` of type `#{var_type}`"
+
+          %{error | message: enriched}
+        else
+          _ -> error
+        end
+
+      _ ->
+        error
+    end
+  end
+
+  def enrich_error_message(error, _query_text), do: error
+
+  # Extracts the variable name (without $) at the given line/column in the query text.
+  defp extract_variable_at(query_text, line, column) do
+    query_text
+    |> String.split("\n")
+    |> Enum.at(line - 1)
+    |> case do
+      nil ->
+        nil
+
+      source_line ->
+        # column is 1-indexed; extract from that position onwards
+        rest = String.slice(source_line, max(column - 1, 0)..-1//1)
+
+        case Regex.run(~r/^\$([a-zA-Z_]\w*)/, rest) do
+          [_, name] -> name
+          _ -> nil
+        end
+    end
+  end
+
+  # Finds the declared type of a variable by scanning operation definitions.
+  # Looks for patterns like `$name: Type` or `$name: Type!` or `$name: [Type!]!`
+  defp find_variable_type(query_text, var_name) do
+    # Match $var_name followed by : and its type annotation.
+    # The type can include [], !, and nested combinations.
+    # We capture up to the next comma, closing paren, or equals sign (default value).
+    pattern = Regex.compile!("\\$" <> Regex.escape(var_name) <> "\\s*:\\s*([^,)=]+)")
+
+    case Regex.run(pattern, query_text) do
+      [_, type_str] -> String.trim(type_str)
+      _ -> nil
+    end
   end
 end

--- a/lib/graphql_query/validator.ex
+++ b/lib/graphql_query/validator.ex
@@ -12,6 +12,7 @@ defmodule GraphqlQuery.Validator do
     DocumentInfo,
     Fragment,
     Native,
+    Parser,
     SchemaInformation,
     ValidationWarning
   }
@@ -167,8 +168,6 @@ defmodule GraphqlQuery.Validator do
 
   @doc false
   def emit_validation_diagnostics(items, warn_location, prefix, document, item_to_ve_fn) do
-    alias GraphqlQuery.Parser
-
     line_map = Parser.build_line_map(document)
     query_text = GraphqlQuery.extract_query_text(document)
 

--- a/lib/graphql_query/validator.ex
+++ b/lib/graphql_query/validator.ex
@@ -164,4 +164,21 @@ defmodule GraphqlQuery.Validator do
   defp clean_result({:ok, []}), do: :ok
   defp clean_result({:ok, warnings}) when is_list(warnings), do: {:ok, warnings}
   defp clean_result(other), do: other
+
+  @doc false
+  def emit_validation_diagnostics(items, warn_location, prefix, document, item_to_ve_fn) do
+    alias GraphqlQuery.Parser
+
+    line_map = Parser.build_line_map(document)
+    query_text = GraphqlQuery.extract_query_text(document)
+
+    Enum.map(items, fn item ->
+      ve = item_to_ve_fn.(item)
+      ve = Parser.enrich_error_message(ve, query_text)
+      {ve, frag_ctx} = GraphqlQuery.maybe_adjust_for_fragment(ve, line_map)
+      formatted = Parser.format_error(ve, warn_location, prefix)
+      message = GraphqlQuery.append_fragment_context(formatted.message, frag_ctx)
+      {message, formatted.location}
+    end)
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -126,7 +126,8 @@ defmodule GraphqlQuery.MixProject do
         "mix.exs",
         "README.md",
         "VERSION",
-        "LICENSE"
+        "LICENSE",
+        "THIRD_PARTY_LICENSES.md"
       ],
       licenses: ["Beerware"],
       links: %{"GitHub" => @source_url},

--- a/test/graphql_query_test.exs
+++ b/test/graphql_query_test.exs
@@ -2728,7 +2728,8 @@ defmodule GraphqlQueryTest do
         |> length()
 
       # split produces N+1 parts for N occurrences
-      assert occurrences == 2, "Expected exactly 1 occurrence of [GraphqlQuery], got #{occurrences - 1}"
+      assert occurrences == 2,
+             "Expected exactly 1 occurrence of [GraphqlQuery], got #{occurrences - 1}"
     end
 
     test "~GQL with multiple errors on different lines reports correct lines" do
@@ -2784,7 +2785,9 @@ defmodule GraphqlQueryTest do
       }
 
       enriched = Parser.enrich_error_message(error, query)
-      assert enriched.message == "expected value of type ID, found variable `$id` of type `String!`"
+
+      assert enriched.message ==
+               "expected value of type ID, found variable `$id` of type `String!`"
     end
 
     test "type mismatch in input object enriches variable info" do
@@ -2805,7 +2808,9 @@ defmodule GraphqlQueryTest do
       }
 
       enriched = Parser.enrich_error_message(error, query)
-      assert enriched.message == "expected value of type ID!, found variable `$traveller_guid` of type `String!`"
+
+      assert enriched.message ==
+               "expected value of type ID!, found variable `$traveller_guid` of type `String!`"
     end
 
     test "non-matching messages are not altered by enrichment" do
@@ -2832,7 +2837,9 @@ defmodule GraphqlQueryTest do
       }
 
       enriched = Parser.enrich_error_message(error, query)
-      assert enriched.message == "expected value of type [String!]!, found variable `$ids` of type `[ID!]!`"
+
+      assert enriched.message ==
+               "expected value of type [String!]!, found variable `$ids` of type `[ID!]!`"
     end
 
     test "enrichment handles variable with default value" do
@@ -2846,7 +2853,9 @@ defmodule GraphqlQueryTest do
       }
 
       enriched = Parser.enrich_error_message(error, query)
-      assert enriched.message == "expected value of type ID, found variable `$name` of type `String!`"
+
+      assert enriched.message ==
+               "expected value of type ID, found variable `$name` of type `String!`"
     end
   end
 

--- a/test/graphql_query_test.exs
+++ b/test/graphql_query_test.exs
@@ -2467,6 +2467,389 @@ defmodule GraphqlQueryTest do
     end
   end
 
+  describe "warning line/column accuracy" do
+    test "~GQL sigil reports correct line for errors" do
+      # The unused variable is on line 6 of the source
+      code = ~S'''
+      defmodule TestSigilLine do
+        import GraphqlQuery
+
+        def test do
+          ~GQL"""
+          query GetUser($unused: String) {
+            user {
+              id
+            }
+          }
+          """
+        end
+      end
+      '''
+
+      logs =
+        ExUnit.CaptureIO.capture_io(:stderr, fn ->
+          Code.compile_string(code, "lib/test_sigil_line.ex")
+        end)
+
+      # Line 6 is where "query GetUser($unused: String) {" is
+      assert logs =~ "test_sigil_line.ex:6"
+    end
+
+    test "gql heredoc with module attribute reports correct line for errors" do
+      # Use Code.compile_string to have proper module attribute resolution
+      code = """
+      defmodule TestGqlHeredocLine do
+        import GraphqlQuery
+
+        @fields "id name"
+
+        def test do
+          gql \"\"\"
+          query GetUser($unused: String) {
+            user {
+              \#{@fields}
+            }
+          }
+          \"\"\"
+        end
+      end
+      """
+
+      logs =
+        ExUnit.CaptureIO.capture_io(:stderr, fn ->
+          Code.compile_string(code, "lib/test_gql_heredoc_line.ex")
+        end)
+
+      # Should report unused variable at the correct line
+      assert logs =~ "unused variable"
+      # Line 8 is where "query GetUser($unused: String) {" is
+      assert logs =~ "test_gql_heredoc_line.ex:8"
+    end
+
+    test "gql single-line string reports correct line for errors" do
+      code = ~S'''
+      defmodule TestGqlInlineLine do
+        import GraphqlQuery
+
+        def test do
+          gql [ignore: true], "query GetUser($unused: String) { user { id } }"
+        end
+      end
+      '''
+
+      # Should compile without warnings (ignore: true)
+      logs =
+        ExUnit.CaptureIO.capture_io(:stderr, fn ->
+          Code.compile_string(code, "lib/test_gql_inline_line.ex")
+        end)
+
+      refute logs =~ "[GraphqlQuery]"
+    end
+
+    test "gql_from_file reports correct line within external file" do
+      code = ~S'''
+      defmodule TestGqlFromFileLine do
+        import GraphqlQuery
+
+        def test do
+          gql_from_file("test/fixtures/invalid_query.graphql")
+        end
+      end
+      '''
+
+      logs =
+        ExUnit.CaptureIO.capture_io(:stderr, fn ->
+          Code.compile_string(code, "lib/test_gql_from_file_line.ex")
+        end)
+
+      # Error should be at line 1 of the .graphql file, not offset by caller line
+      assert logs =~ "invalid_query.graphql:1"
+      refute logs =~ "invalid_query.graphql:6"
+      refute logs =~ "invalid_query.graphql:7"
+    end
+
+    test "error after fragment spread reports correct line" do
+      code = ~S'''
+      defmodule TestAfterSpreadLine do
+        import GraphqlQuery
+
+        @user_fragment ~GQL"""
+        fragment UserFields on User {
+          name
+          email
+        }
+        """f
+
+        def test do
+          document_with_options fragments: [@user_fragment] do
+            ~GQL"""
+            query GetUser($id: ID!) {
+              user(id: $id) {
+                ...UserFields
+                ...MissingFragment
+              }
+            }
+            """
+          end
+        end
+      end
+      '''
+
+      logs =
+        ExUnit.CaptureIO.capture_io(:stderr, fn ->
+          Code.compile_string(code, "lib/test_after_spread.ex")
+        end)
+
+      assert logs =~ "cannot find fragment `MissingFragment`"
+      # ...MissingFragment is on line 17
+      assert logs =~ "test_after_spread.ex:17"
+    end
+
+    test "error in external fragment includes fragment context" do
+      code = ~S'''
+      defmodule TestFragCtxLine do
+        import GraphqlQuery
+
+        @user_fragment ~GQL"""
+        fragment UserFields on User {
+          name
+          ...NestedMissing
+        }
+        """f
+
+        def test do
+          document_with_options fragments: [@user_fragment] do
+            ~GQL"""
+            query GetUser($id: ID!) {
+              user(id: $id) {
+                ...UserFields
+              }
+            }
+            """
+          end
+        end
+      end
+      '''
+
+      logs =
+        ExUnit.CaptureIO.capture_io(:stderr, fn ->
+          Code.compile_string(code, "lib/test_frag_ctx.ex")
+        end)
+
+      assert logs =~ "cannot find fragment `NestedMissing`"
+      assert logs =~ "in fragment 'UserFields'"
+      assert logs =~ "included via fragments option"
+      # Should point to the ...UserFields spread line (line 16), not the ~GQL line
+      assert logs =~ "test_frag_ctx.ex:16"
+    end
+
+    test "error in external fragment with multiple fragments points to correct spread" do
+      code = ~S'''
+      defmodule TestMultiFragSpread do
+        import GraphqlQuery
+
+        @addr_fragment ~GQL"""
+        fragment AddressFields on Address {
+          street
+          ...BadNested
+        }
+        """f
+
+        @user_fragment ~GQL"""
+        fragment UserFields on User {
+          name
+          email
+        }
+        """f
+
+        def test do
+          document_with_options fragments: [@user_fragment, @addr_fragment] do
+            ~GQL"""
+            query GetUser($id: ID!) {
+              user(id: $id) {
+                ...UserFields
+                address {
+                  ...AddressFields
+                }
+              }
+            }
+            """
+          end
+        end
+      end
+      '''
+
+      logs =
+        ExUnit.CaptureIO.capture_io(:stderr, fn ->
+          Code.compile_string(code, "lib/test_multi_frag_spread.ex")
+        end)
+
+      assert logs =~ "cannot find fragment `BadNested`"
+      assert logs =~ "in fragment 'AddressFields'"
+      # Should point to the ...AddressFields spread line (line 25)
+      assert logs =~ "test_multi_frag_spread.ex:25"
+    end
+
+    test "runtime validation does not have double prefix" do
+      code = ~S'''
+      defmodule TestRuntimeNoDoublePrefix do
+        import GraphqlQuery
+        require Logger
+
+        def test do
+          gql [runtime: true], """
+          query GetUser($unused: String) {
+            user {
+              id
+            }
+          }
+          """
+        end
+      end
+      '''
+
+      Code.compile_string(code, "lib/test_rt_prefix.ex")
+
+      {_query, logs} =
+        ExUnit.CaptureLog.with_log(fn ->
+          {query, _} =
+            Code.eval_string("TestRuntimeNoDoublePrefix.test()")
+
+          query
+        end)
+
+      # Should contain exactly one [GraphqlQuery] prefix, not doubled
+      assert logs =~ "[GraphqlQuery]"
+
+      # Count occurrences of the prefix - should be exactly 1
+      occurrences =
+        logs
+        |> String.split("[GraphqlQuery]")
+        |> length()
+
+      # split produces N+1 parts for N occurrences
+      assert occurrences == 2, "Expected exactly 1 occurrence of [GraphqlQuery], got #{occurrences - 1}"
+    end
+
+    test "~GQL with multiple errors on different lines reports correct lines" do
+      code = ~S'''
+      defmodule TestMultiErrorLines do
+        import GraphqlQuery
+
+        def test do
+          ~GQL"""
+          {
+            user {
+              id
+            }
+          }
+
+          query Q2($unused: String) {
+            posts {
+              title
+            }
+          }
+          """
+        end
+      end
+      '''
+
+      logs =
+        ExUnit.CaptureIO.capture_io(:stderr, fn ->
+          Code.compile_string(code, "lib/test_multi_error.ex")
+        end)
+
+      # Line 6 = the anonymous operation { (line 1 of GQL + sigil at line 5)
+      assert logs =~ "test_multi_error.ex:6"
+      # Line 12 = query Q2 (line 7 of GQL + sigil at line 5)
+      assert logs =~ "test_multi_error.ex:12"
+    end
+
+    test "type mismatch enriches 'found a variable' with variable name and type" do
+      # The "found a variable" message is produced by apollo-compiler's UnsupportedValueType
+      # diagnostic, which occurs when a variable is used for an input object field.
+      # Direct argument mismatches produce a different, already-rich message.
+      # Test via Parser.enrich_error_message directly with the exact pattern.
+      alias GraphqlQuery.{Parser, ValidationError, Location}
+
+      query = """
+      query Test($id: String!) {
+        eval(data: {userId: $id}) { result }
+      }
+      """
+
+      error = %ValidationError{
+        message: "expected value of type ID, found a variable",
+        locations: [%Location{line: 2, column: 23}]
+      }
+
+      enriched = Parser.enrich_error_message(error, query)
+      assert enriched.message == "expected value of type ID, found variable `$id` of type `String!`"
+    end
+
+    test "type mismatch in input object enriches variable info" do
+      # Direct test of the Parser.enrich_error_message function
+      alias GraphqlQuery.{Parser, ValidationError, Location}
+
+      query = """
+      query EvalTrip($traveller_guid: String!, $guest: Boolean) {
+        eval(tripData: {travellerGuid: $traveller_guid, guest: $guest}) {
+          compliant
+        }
+      }
+      """
+
+      error = %ValidationError{
+        message: "expected value of type ID!, found a variable",
+        locations: [%Location{line: 2, column: 34}]
+      }
+
+      enriched = Parser.enrich_error_message(error, query)
+      assert enriched.message == "expected value of type ID!, found variable `$traveller_guid` of type `String!`"
+    end
+
+    test "non-matching messages are not altered by enrichment" do
+      alias GraphqlQuery.{Parser, ValidationError, Location}
+
+      query = "query Test($id: ID!) { user(id: $id) { id } }"
+
+      error = %ValidationError{
+        message: "unused variable: `$foo`",
+        locations: [%Location{line: 1, column: 12}]
+      }
+
+      assert Parser.enrich_error_message(error, query).message == "unused variable: `$foo`"
+    end
+
+    test "enrichment handles list and nullable types" do
+      alias GraphqlQuery.{Parser, ValidationError, Location}
+
+      query = "query Test($ids: [ID!]!) { users(ids: $ids) { id } }"
+
+      error = %ValidationError{
+        message: "expected value of type [String!]!, found a variable",
+        locations: [%Location{line: 1, column: 39}]
+      }
+
+      enriched = Parser.enrich_error_message(error, query)
+      assert enriched.message == "expected value of type [String!]!, found variable `$ids` of type `[ID!]!`"
+    end
+
+    test "enrichment handles variable with default value" do
+      alias GraphqlQuery.{Parser, ValidationError, Location}
+
+      query = ~s|query Test($name: String! = "default") { user(name: $name) { id } }|
+
+      error = %ValidationError{
+        message: "expected value of type ID, found a variable",
+        locations: [%Location{line: 1, column: 53}]
+      }
+
+      enriched = Parser.enrich_error_message(error, query)
+      assert enriched.message == "expected value of type ID, found variable `$name` of type `String!`"
+    end
+  end
+
   defp with_tmp_file(content, callback) do
     file_path = "test_#{abs(:erlang.unique_integer())}"
     File.write!(file_path, content)

--- a/test/graphql_query_test.exs
+++ b/test/graphql_query_test.exs
@@ -2771,7 +2771,7 @@ defmodule GraphqlQueryTest do
       # diagnostic, which occurs when a variable is used for an input object field.
       # Direct argument mismatches produce a different, already-rich message.
       # Test via Parser.enrich_error_message directly with the exact pattern.
-      alias GraphqlQuery.{Parser, ValidationError, Location}
+      alias GraphqlQuery.{Location, Parser, ValidationError}
 
       query = """
       query Test($id: String!) {
@@ -2792,7 +2792,7 @@ defmodule GraphqlQueryTest do
 
     test "type mismatch in input object enriches variable info" do
       # Direct test of the Parser.enrich_error_message function
-      alias GraphqlQuery.{Parser, ValidationError, Location}
+      alias GraphqlQuery.{Location, Parser, ValidationError}
 
       query = """
       query EvalTrip($traveller_guid: String!, $guest: Boolean) {
@@ -2814,7 +2814,7 @@ defmodule GraphqlQueryTest do
     end
 
     test "non-matching messages are not altered by enrichment" do
-      alias GraphqlQuery.{Parser, ValidationError, Location}
+      alias GraphqlQuery.{Location, Parser, ValidationError}
 
       query = "query Test($id: ID!) { user(id: $id) { id } }"
 
@@ -2827,7 +2827,7 @@ defmodule GraphqlQueryTest do
     end
 
     test "enrichment handles list and nullable types" do
-      alias GraphqlQuery.{Parser, ValidationError, Location}
+      alias GraphqlQuery.{Location, Parser, ValidationError}
 
       query = "query Test($ids: [ID!]!) { users(ids: $ids) { id } }"
 
@@ -2843,7 +2843,7 @@ defmodule GraphqlQueryTest do
     end
 
     test "enrichment handles variable with default value" do
-      alias GraphqlQuery.{Parser, ValidationError, Location}
+      alias GraphqlQuery.{Location, Parser, ValidationError}
 
       query = ~s|query Test($name: String! = "default") { user(name: $name) { id } }|
 

--- a/test/graphql_query_test.exs
+++ b/test/graphql_query_test.exs
@@ -2795,8 +2795,8 @@ defmodule GraphqlQueryTest do
       alias GraphqlQuery.{Location, Parser, ValidationError}
 
       query = """
-      query EvalTrip($traveller_guid: String!, $guest: Boolean) {
-        eval(tripData: {travellerGuid: $traveller_guid, guest: $guest}) {
+      query EvalTrip($guid: String!, $guest: Boolean) {
+        eval(tripData: {guid: $guid, guest: $guest}) {
           compliant
         }
       }
@@ -2804,13 +2804,13 @@ defmodule GraphqlQueryTest do
 
       error = %ValidationError{
         message: "expected value of type ID!, found a variable",
-        locations: [%Location{line: 2, column: 34}]
+        locations: [%Location{line: 2, column: 25}]
       }
 
       enriched = Parser.enrich_error_message(error, query)
 
       assert enriched.message ==
-               "expected value of type ID!, found variable `$traveller_guid` of type `String!`"
+               "expected value of type ID!, found variable `$guid` of type `String!`"
     end
 
     test "non-matching messages are not altered by enrichment" do


### PR DESCRIPTION
Fixed:
- Warning line and column numbers are now accurate for all macro variants (~GQL sigil, gql heredoc, gql inline string, gql_from_file). Previously, line numbers were off by one due to a spurious +1 in the offset calculation.
- Single-line gql("...") string arguments now correctly map errors to the call site line.
- gql_from_file errors now report lines relative to the external file rather than the call site.
- Runtime validation no longer double-formats error messages.

Improved:
- Validation errors originating in external fragments (via fragments: option) now include context with the fragment name and line, and point to the ...FragmentName spread in the query rather than the sigil line.
- 'expected value of type X, found a variable' messages are now enriched with the variable name and declared type, e.g. 'found variable `$traveller_guid` of type `String!`'
- Added THIRD_PARTY_LICENSES.md for apollo-compiler (MIT/Apache-2.0).

Added 18 new tests covering all of the above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate error/warning locations for inline, single-line, and external-file queries
  * Runtime validation no longer double-formats messages
  * Fragment validation errors now reference the fragment spread and include surrounding context
  * Type-mismatch diagnostics enriched with variable name and declared type

* **Documentation**
  * Added third-party licenses and clarified license notice for the parsing/validation dependency

* **Tests**
  * New diagnostics tests covering line/column accuracy and message enrichment

* **Chores**
  * Included third-party licenses in packaged files
<!-- end of auto-generated comment: release notes by coderabbit.ai -->