### PR TITLE
fix: escape full `@deprecated` reason correctly

### DIFF
--- a/lib/graphql_query/schema/remote/introspection.ex
+++ b/lib/graphql_query/schema/remote/introspection.ex
@@ -409,8 +409,7 @@ defmodule GraphqlQuery.Schema.Remote.Introspection do
   # Deprecation
   defp render_deprecated(%{"isDeprecated" => true, "deprecationReason" => reason})
        when is_binary(reason) and reason != "" do
-    escaped = reason |> String.replace("\\", "\\\\") |> String.replace("\"", "\\\"")
-    " @deprecated(reason: \"#{escaped}\")"
+    " @deprecated(reason: \"#{escape_string_value(reason)}\")"
   end
 
   defp render_deprecated(%{"isDeprecated" => true}) do
@@ -418,6 +417,28 @@ defmodule GraphqlQuery.Schema.Remote.Introspection do
   end
 
   defp render_deprecated(_), do: ""
+
+  # escape StringValue following spec at
+  # https://spec.graphql.org/September2025/#sec-String)
+  defp escape_string_value(reason) do
+    reason
+    |> String.to_charlist()
+    |> Enum.map_join(&escape_codepoint/1)
+  end
+
+  defp escape_codepoint(?\\), do: "\\\\"
+  defp escape_codepoint(?"), do: "\\\""
+  defp escape_codepoint(?\b), do: "\\b"
+  defp escape_codepoint(?\f), do: "\\f"
+  defp escape_codepoint(?\n), do: "\\n"
+  defp escape_codepoint(?\r), do: "\\r"
+  defp escape_codepoint(?\t), do: "\\t"
+
+  defp escape_codepoint(c) when c < 0x20 or (c >= 0x7F and c <= 0x9F) do
+    "\\u" <> (c |> Integer.to_string(16) |> String.pad_leading(4, "0"))
+  end
+
+  defp escape_codepoint(c), do: <<c::utf8>>
 
   # Default values — stored as JSON-encoded strings in introspection
   defp render_default_value(nil), do: ""

--- a/test/graphql_query/schema/remote/introspection_test.exs
+++ b/test/graphql_query/schema/remote/introspection_test.exs
@@ -178,6 +178,81 @@ defmodule GraphqlQuery.Schema.Remote.IntrospectionTest do
       assert sdl =~ "directive @deprecated"
     end
 
+    test "escapes control characters in deprecation reasons so the SDL parses" do
+      schema = %{
+        "queryType" => %{"name" => "Query"},
+        "mutationType" => nil,
+        "subscriptionType" => nil,
+        "directives" => [],
+        "types" => [
+          %{
+            "kind" => "OBJECT",
+            "name" => "Query",
+            "description" => nil,
+            "interfaces" => [],
+            "fields" => [
+              %{
+                "name" => "old",
+                "description" => nil,
+                "args" => [],
+                "type" => %{"kind" => "SCALAR", "name" => "String", "ofType" => nil},
+                "isDeprecated" => true,
+                "deprecationReason" => "Use `new` instead.\nSee the docs for details.\n"
+              }
+            ],
+            "inputFields" => nil,
+            "enumValues" => nil,
+            "possibleTypes" => nil
+          }
+        ]
+      }
+
+      {:ok, sdl} = Introspection.to_sdl(schema)
+      assert sdl =~ ~S|@deprecated(reason: "Use `new` instead.\nSee the docs for details.\n")|
+      assert {:ok, _} = GraphqlQuery.Native.validate_schema(sdl, "test.graphql")
+    end
+
+    test "escapes the full set of GraphQL StringValue escapes in deprecation reasons" do
+      reason =
+        "quote:\" backslash:\\ bs:\b ff:\f lf:\n cr:\r tab:\t soh:\x01 nel:\u0085 unicode:café"
+
+      schema = %{
+        "queryType" => %{"name" => "Query"},
+        "mutationType" => nil,
+        "subscriptionType" => nil,
+        "directives" => [],
+        "types" => [
+          %{
+            "kind" => "OBJECT",
+            "name" => "Query",
+            "description" => nil,
+            "interfaces" => [],
+            "fields" => [
+              %{
+                "name" => "old",
+                "description" => nil,
+                "args" => [],
+                "type" => %{"kind" => "SCALAR", "name" => "String", "ofType" => nil},
+                "isDeprecated" => true,
+                "deprecationReason" => reason
+              }
+            ],
+            "inputFields" => nil,
+            "enumValues" => nil,
+            "possibleTypes" => nil
+          }
+        ]
+      }
+
+      {:ok, sdl} = Introspection.to_sdl(schema)
+
+      expected =
+        "@deprecated(reason: \"quote:\\\" backslash:\\\\ bs:\\b ff:\\f lf:\\n cr:\\r tab:\\t soh:\\u0001 nel:\\u0085 unicode:café\")"
+
+      assert sdl =~ expected
+      assert {:ok, _} = GraphqlQuery.Native.validate_schema(sdl, "test.graphql")
+    end
+
     test "does not emit schema definition for standard root type names" do
       json = load_fixture()
       {:ok, sdl} = Introspection.to_sdl(json)


### PR DESCRIPTION
Currently if you use the remote schema with a schema that has newlines in the deprecated reason string it crashes. The cause is the [render_deprecated/1](https://github.com/rockneurotiko/graphql_query/blob/c687a0f1a641748622087db9fe57f9a4351c88d3/lib/graphql_query/schema/remote/introspection.ex#L410C8-L410C25) function which only escaped `\` and `"` before now it escapes all characters from the graphql spec for [StringValue](https://spec.graphql.org/September2025/#sec-String) specifically added support for characters `\b`, `\r`, `\n`, `\f`, `\t` along with a range of unicode characters from the spec.

If you have feedback eg. want to add a fixture to tests etc or think it's overkill supporting all of them I can change it.

PS, thanks for adding support for downloading remote schemas I was using a mix task calling a js package to do this before and I saw you updated the README saying this library is used in prod

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of special characters and Unicode in GraphQL deprecation reason values.

* **Tests**
  * Added comprehensive tests for string escaping validation in GraphQL schema generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->